### PR TITLE
Fixed incorrect latency reporting for load phase.

### DIFF
--- a/src/main/java/com/facebook/LinkBench/LinkBenchLoad.java
+++ b/src/main/java/com/facebook/LinkBench/LinkBenchLoad.java
@@ -455,7 +455,7 @@ public class LinkBenchLoad implements Runnable {
         stats.addStats(LinkBenchOp.LOAD_LINK, timetaken/1000, false);
 
         latencyStats.recordLatency(loaderID,
-                      LinkBenchOp.LOAD_LINK, timetaken);
+                      LinkBenchOp.LOAD_LINK, timetaken/1000);
       }
 
     } catch (Throwable e){//Catch exception if any
@@ -483,7 +483,7 @@ public class LinkBenchLoad implements Runnable {
       stats.addStats(LinkBenchOp.LOAD_LINKS_BULK_NLINKS, nlinks, false);
 
       latencyStats.recordLatency(loaderID, LinkBenchOp.LOAD_LINKS_BULK,
-                                                             timetaken);
+                                                             timetaken/1000);
     } catch (Throwable e){//Catch exception if any
         long endtime2 = System.nanoTime();
         long timetaken2 = (endtime2 - timestart)/1000;
@@ -509,7 +509,7 @@ public class LinkBenchLoad implements Runnable {
       stats.addStats(LinkBenchOp.LOAD_COUNTS_BULK_NLINKS, ncounts, false);
 
       latencyStats.recordLatency(loaderID, LinkBenchOp.LOAD_COUNTS_BULK,
-                                                             timetaken);
+                                                             timetaken/1000);
     } catch (Throwable e){//Catch exception if any
         long endtime2 = System.nanoTime();
         long timetaken2 = (endtime2 - timestart)/1000;

--- a/src/main/java/com/facebook/LinkBench/NodeLoader.java
+++ b/src/main/java/com/facebook/LinkBench/NodeLoader.java
@@ -199,7 +199,7 @@ public class NodeLoader implements Runnable {
       // convert to microseconds
       stats.addStats(LinkBenchOp.LOAD_NODE_BULK, timetaken/1000, false);
       latencyStats.recordLatency(loaderId,
-                    LinkBenchOp.LOAD_NODE_BULK, timetaken);
+                    LinkBenchOp.LOAD_NODE_BULK, timetaken/1000);
 
       if (nodesLoaded >= nextReport) {
         double totalTimeTaken = (System.currentTimeMillis() - startTime_ms) / 1000.0;


### PR DESCRIPTION
LinkBenchLoad and NodeLoader call the recordLatency method of LatencyStats with
time measured in nanoseconds, instead of microseconds, as recordLatnecy
expects. This fix scales the time measurement by 1000 to convert to
microseconds.